### PR TITLE
added tfmpl to yml and fixed bug to run on all GPUs

### DIFF
--- a/beepose.yml
+++ b/beepose.yml
@@ -155,5 +155,6 @@ dependencies:
     - tabulate==0.8.6
     - tensorflow-gpu==1.9.0
     - tensorpack==0.9.8
+    - tfmpl==1.0.2 
 prefix: /home/jchan/anaconda3/envs/beepose
 

--- a/beepose/train/train_stages_aug.py
+++ b/beepose/train/train_stages_aug.py
@@ -224,7 +224,7 @@ def main():
     np1= np2 * 2#12 #number of channels for pafs
 #     numparts = np2 
     mapIdx = get_skeleton_mapIdx(numparts)
-    gpu = int(args.gpu)
+    gpu = args.gpu
     batch_size = int(args.batch_size)
     
     base_lr = 4e-5 
@@ -254,9 +254,9 @@ def main():
     
     config = tf.ConfigProto()
     if gpu != 'all':
-        config.gpu_options.visible_device_list= "%d"%gpu
+        config.gpu_options.visible_device_list= "%d"%int(gpu)
         os.environ["CUDA_DEVICE_ORDER"]="PCI_BUS_ID"
-        os.environ["CUDA_VISIBLE_DEVICES"]="%d"%gpu
+        os.environ["CUDA_VISIBLE_DEVICES"]="%d"%int(gpu)
     config.gpu_options.per_process_gpu_memory_fraction = fraction
     session = tf.Session(config=config)
     


### PR DESCRIPTION
tfmpl is now required for training in beepose/beepose/train/custom_callbacks.py
